### PR TITLE
Publish tags to NPM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,33 @@ jobs:
           paths: .
       - store_artifacts:
           path: ~/repo/dist
+  deploy:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Configure registry auth
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" >> ~/repo/.npmrc
+      - run:
+          name: Publish package
+          # For now we only publish on tags here and assume the version number is already correct.
+          # If we change this then we need to automate updating the version number.
+          command: npm publish $(if [ -z "$CIRCLE_TAG" ]; then echo "--tag next"; fi)
 
 workflows:
   version: 2
-  test:
+  test-deploy:
     jobs:
-      - test_and_build
+      - test_and_build:
+          filters:
+            tags:
+              only: /^v.*/
+      - deploy:
+          requires:
+            - test_and_build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
I think this is the minimum we can do to get this published in a repeatable way.

It publishes for version tags only.

It assumes the package.json version number is correct (rather than deriving it from the tag as we've done elsewhere). We can revisit that later. Using automation here would be good if we started publishing @next tagged builds from master, which might help people trying out bug fixes etc.

- [x] Needs auth configuring in CircleCI before merge.
- [x] Needs discussion of first release, e.g. 0.7.1 with release note that says "First release in NPM; no other changes" ?