### PR TITLE
Fix types paths in exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/esm/index.d.js",
+        "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "types": "./dist/cjs/index.d.js",
+        "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.js"
       }
     }


### PR DESCRIPTION
The types conditions pointed at index.d.js, which does not exist. tsc strips the .js extension and finds index.d.ts beside it, so consumers were unaffected, but tools that read exports literally flag it.